### PR TITLE
rel 3.10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 - Treat `device*.c`, `unit*.c`, `unit_commands*.c`, `unit_io.c`, `unit_task.c`, and `genet.device/include/device.h` as the cautious dual-licensed SANA-II scaffolding track: they resemble generic SANA-II drivers and also WiFiPi more specifically, so do not casually relicense them.
 - Treat `genet.device/src/devtree_parse.c`, `genet.device/include/genet/bcmgenet.h`, and `runtime-config/*` as original repository files currently licensed `GPL-2.0+`.
 - Treat the hardware-facing `bcmgenet*`, `phy*`, and imported `include/genet/*` headers as Linux/U-Boot-derived GPL-family material and preserve their file-level SPDX identifiers.
-- The README documents a soft-reboot hang when the driver is online; be cautious with interrupt enable and teardown changes.
+- A reset guard quiesces GENET DMA before the Amiga resets (both Ctrl-Amiga-Amiga and `ColdReboot()` / `C:Reboot`); be cautious with interrupt enable, teardown, and reset-guard changes.
 
 ## Validation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-genet-driver VERSION 3.9)
+project(emu68-genet-driver VERSION 3.10)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-genet-driver VERSION 3.8)
+project(emu68-genet-driver VERSION 3.9)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ The hardware-facing GENET and PHY implementation is based primarily on [Das U-Bo
 ## Unimplemented / Planned Features
 
 - PHY link state updates at runtime
-- Better shutdown / reset handling
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ The hardware-facing GENET and PHY implementation is based primarily on [Das U-Bo
 
 ## Known bugs
 
-- Amiga may get stuck at boot if you soft reboot while the driver is online
+- None currently known.
 
 ## What's new
+3.10:
+- Added a reset guard: the driver now quiesces GENET DMA before the Amiga resets (both Ctrl-Amiga-Amiga and `ColdReboot()` / `C:Reboot`).
+- Reworked unit memory management to use separate pools: DMA buffers are allocated from a region-restricted pool in Pistorm RAM that the GENET DMA engine can reach, while CPU-only metadata uses an ordinary Exec pool. DMA reachability is now decided by an explicit predicate instead of a hardcoded address check.
+- Added a `CachePreDMA()` call for the RX buffer to ensure cache coherency before the controller starts writing into it.
+
 3.8:
 - TX and RX memory handling reworked again: the TX path now uses the common slab allocator, RX ring buffers use `dma_zalloc()`, and TX completion handling no longer depends on TX IRQs.
 - Request flow is more robust under load: `CMD_READ` uses an SPSC ring, `CMD_WRITE` is handled only in user context, and TX reclaim runs in the bottom half.

--- a/genet.device/CMakeLists.txt
+++ b/genet.device/CMakeLists.txt
@@ -77,6 +77,9 @@ target_link_libraries(genet.device
         GIC400::gic400_headers
 )
 
+# ROM-able: no writable .data/.bss may sneak in
+emu68_rom_check(genet.device)
+
 install(
     PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/genet.device
     DESTINATION DEVS/Networks

--- a/genet.device/include/device.h
+++ b/genet.device/include/device.h
@@ -15,6 +15,7 @@
 #include <types.h>
 #include <bcm_gpio.h>
 #include <slab.h>
+#include <dma_mem.h>
 #include <reset_guard.h>
 
 #include <genet/phy.h>
@@ -179,7 +180,9 @@ struct throughput_stats
 struct GenetUnit
 {
 	struct Unit unit;
-	APTR memoryPool;
+	struct dma_mem_ctx dma_ctx; /* Emu68 (DMA-reachable) RAM regions; backs dmaPool */
+	struct dma_pool *dmaPool;	/* region-restricted DMA pool (Emu68 RAM) for DMA buffers */
+	APTR metaPool;				/* ordinary Exec pool for CPU-only metadata */
 	struct GenetDevice *device;
 
 	/* config */

--- a/genet.device/include/device.h
+++ b/genet.device/include/device.h
@@ -15,6 +15,7 @@
 #include <types.h>
 #include <bcm_gpio.h>
 #include <slab.h>
+#include <reset_guard.h>
 
 #include <genet/phy.h>
 #include <genet/bcmgenet.h>
@@ -262,6 +263,7 @@ struct GenetDevice
 	struct GenetRuntimeConfig runtimeConfig;
 	struct Library *utilityBase;
 	struct Library *gic400Base;
+	struct reset_guard resetGuard; /* pre-reset DMA quiesce hooks */
 
 	// For now, we'll just assume there can be only one unit
 	struct GenetUnit *unit;

--- a/genet.device/include/genet/bcmgenet.h
+++ b/genet.device/include/genet/bcmgenet.h
@@ -12,6 +12,7 @@ struct IOSana2Req;
 u32 bcmgenet_eth_probe(struct GenetUnit *unit);
 u32 bcmgenet_gmac_eth_start(struct GenetUnit *unit);
 void bcmgenet_gmac_eth_stop(struct GenetUnit *unit);
+void bcmgenet_reset_quiesce(struct GenetUnit *unit);
 u32 bcmgenet_set_coalesce(struct GenetUnit *unit, u32 tx_max_coalesced_frames, u32 rx_max_coalesced_frames, u32 rx_coalesce_usecs);
 void bcmgenet_set_rx_mode(struct GenetUnit *unit); /* Updates PROMISC flag and sets up MDF if possible */
 void bcmgenet_irq0_enable(struct GenetUnit *unit, u32 irq_mask);

--- a/genet.device/src/bcmgenet-tx.c
+++ b/genet.device/src/bcmgenet-tx.c
@@ -144,14 +144,15 @@ u32 bcmgenet_xmit(struct IOSana2Req *io, struct GenetUnit *unit)
 		if (unlikely(opener->DMACopyFromBuff))
 		{
 			dma_addr_t d = (dma_addr_t)opener->DMACopyFromBuff(io->ios2_Data);
-			// TODO not only CHIP, we only can use memory provided by PI4!
-			if (likely(d > 0x1FFFFFUL))
+			/* GENET DMA can only reach Emu68 (Pi-DRAM) RAM; Chip RAM and any
+			 * Zorro/accelerator Fast RAM are unreachable -> fall back to copy. */
+			if (likely(dma_addr_reachable(&unit->dma_ctx, (APTR)d, io->ios2_DataLength)))
 			{
 				body_dma = d;
 			}
 			else
 			{
-				KprintfH("[genet] %s: Cannot use CHIP memory buffer, falling back to copy\n", __func__);
+				KprintfH("[genet] %s: buffer not DMA-reachable, falling back to copy\n", __func__);
 			}
 		}
 
@@ -207,7 +208,7 @@ u32 bcmgenet_xmit(struct IOSana2Req *io, struct GenetUnit *unit)
 		if (unlikely(opener->DMACopyFromBuff))
 		{
 			dma_addr_t d = (dma_addr_t)opener->DMACopyFromBuff(io->ios2_Data);
-			if (d > 0x1FFFFFUL)
+			if (dma_addr_reachable(&unit->dma_ctx, (APTR)d, io->ios2_DataLength))
 			{
 				KprintfH("[genet] %s: RAW DMA copy from buffer 0x%lx\n", __func__, d);
 				body_dma = d;

--- a/genet.device/src/bcmgenet.c
+++ b/genet.device/src/bcmgenet.c
@@ -280,7 +280,7 @@ static u32 bcmgenet_init_rx_ring(struct GenetUnit *unit)
 
 	/* Initialize common Rx ring structures */
 	const APTR desc_base = unit->genetBase + GENET_RX_OFF;
-	ring->rx_control_block = AllocPooled(unit->memoryPool, RX_DESCS * sizeof(struct enet_cb));
+	ring->rx_control_block = pool_alloc(unit->metaPool, RX_DESCS * sizeof(struct enet_cb));
 	if (!ring->rx_control_block)
 	{
 		return S2ERR_NO_RESOURCES;
@@ -345,7 +345,7 @@ static u32 bcmgenet_init_tx_ring(struct GenetUnit *unit)
 
 	/* Initialize common TX ring structures */
 	APTR desc_base = unit->genetBase + GENET_TX_OFF;
-	ring->tx_control_block = AllocPooled(unit->memoryPool, TX_DESCS * sizeof(struct enet_cb));
+	ring->tx_control_block = pool_alloc(unit->metaPool, TX_DESCS * sizeof(struct enet_cb));
 	if (!ring->tx_control_block)
 	{
 		return S2ERR_NO_RESOURCES;
@@ -357,7 +357,7 @@ static u32 bcmgenet_init_tx_ring(struct GenetUnit *unit)
 		ring->tx_control_block[i].descriptor_address = desc_base + i * DMA_DESC_SIZE;
 	}
 
-	slab_cache_init(&unit->tx_buffer_cache, unit->memoryPool,
+	slab_cache_init(&unit->tx_buffer_cache, unit->metaPool, unit->dmaPool,
 	                RX_BUF_LENGTH, DMA_ALIGN_MIN, TX_DESCS);
 
 	/* Cannot init TDMA_CONS_INDEX to 0, so align TDMA_PROD_INDEX on it instead */
@@ -558,7 +558,7 @@ u32 bcmgenet_gmac_eth_start(struct GenetUnit *unit)
 	KprintfH("[genet] %s: Starting GENET\n", __func__);
 	u32 ret;
 
-	unit->rxbuffer = (dma_addr_t)dma_zalloc(unit->memoryPool, DMA_ALIGN_MIN, RX_TOTAL_BUFSIZE);
+	unit->rxbuffer = (dma_addr_t)dma_zalloc(unit->dmaPool, DMA_ALIGN_MIN, RX_TOTAL_BUFSIZE);
 	if (!unit->rxbuffer)
 	{
 		Kprintf("[genet] %s: Failed to allocate RX buffer\n", __func__);
@@ -644,7 +644,7 @@ init_dma:
 	slab_cache_destroy(&unit->tx_buffer_cache);
 
 rx_buf_allocated:
-	dma_free(unit->memoryPool, (APTR)unit->rxbuffer);
+	dma_free(unit->dmaPool, (APTR)unit->rxbuffer);
 	unit->rxbuffer = 0;
 
 	return ret;
@@ -758,7 +758,7 @@ void bcmgenet_gmac_eth_stop(struct GenetUnit *unit)
 
 	if (unit->rxbuffer)
 	{
-		dma_free(unit->memoryPool, (APTR)unit->rxbuffer);
+		dma_free(unit->dmaPool, (APTR)unit->rxbuffer);
 		unit->rxbuffer = 0;
 	}
 	slab_cache_destroy(&unit->tx_buffer_cache);

--- a/genet.device/src/bcmgenet.c
+++ b/genet.device/src/bcmgenet.c
@@ -522,7 +522,7 @@ void bcmgenet_set_rx_mode(struct GenetUnit *unit)
 	/* update MDF filter */
 	u8 i = 0;
 	/* Broadcast */
-	const u8 broadcast[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+	static const u8 broadcast[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 	bcmgenet_set_mdf_addr(unit, broadcast, &i);
 	/* my own address.*/
 	bcmgenet_set_mdf_addr(unit, unit->currentMacAddress, &i);
@@ -727,10 +727,12 @@ u32 bcmgenet_eth_probe(struct GenetUnit *unit)
 	return bcmgenet_phy_init(unit);
 }
 
-void bcmgenet_gmac_eth_stop(struct GenetUnit *unit)
+/* Stop all bus-master activity (RX/TX DMA, MAC, interrupts) without
+ * releasing any resources.  Also the pre-reset quiesce: the RX ring keeps
+ * receiving into RAM the next OS session reuses unless this runs before
+ * the machine resets. */
+void bcmgenet_reset_quiesce(struct GenetUnit *unit)
 {
-	KprintfH("[genet] %s: Stopping GENET\n", __func__);
-
 	/* Disable MAC receive */
 	mmio_clear32(BCMGENET_REG(unit, UMAC_CMD), CMD_RX_EN);
 	delay_ms(1);
@@ -740,6 +742,13 @@ void bcmgenet_gmac_eth_stop(struct GenetUnit *unit)
 	delay_ms(1);
 
 	bcmgenet_intr_disable(unit);
+}
+
+void bcmgenet_gmac_eth_stop(struct GenetUnit *unit)
+{
+	KprintfH("[genet] %s: Stopping GENET\n", __func__);
+
+	bcmgenet_reset_quiesce(unit);
 	RemIntServerEx(unit->irq0_number, &unit->irq0_isr);
 
 	/* tx reclaim */

--- a/genet.device/src/bcmgenet.c
+++ b/genet.device/src/bcmgenet.c
@@ -566,6 +566,9 @@ u32 bcmgenet_gmac_eth_start(struct GenetUnit *unit)
 		goto rx_buf_allocated;
 	}
 
+	ULONG rxlen = RX_TOTAL_BUFSIZE;
+	CachePreDMA((APTR)unit->rxbuffer, &rxlen, 0);
+
 	bcmgenet_umac_reset(unit);
 
 	bcmgenet_gmac_write_hwaddr(unit, unit->currentMacAddress);

--- a/genet.device/src/bcmgenet.c
+++ b/genet.device/src/bcmgenet.c
@@ -111,7 +111,7 @@ static void bcmgenet_disable_dma(struct GenetUnit *unit)
 
 	/* Wait 10ms for packet drain in both tx and rx dma */
 	// TODO timer?
-	delay_us(10000);
+	delay_ms(10);
 
 	mmio_clear32(BCMGENET_REG(unit, RDMA_REG_BASE + DMA_CTRL), DMA_EN);
 	for (u32 timeout = 0; timeout < DMA_TIMEOUT_VAL; timeout++)
@@ -730,11 +730,11 @@ void bcmgenet_gmac_eth_stop(struct GenetUnit *unit)
 
 	/* Disable MAC receive */
 	mmio_clear32(BCMGENET_REG(unit, UMAC_CMD), CMD_RX_EN);
-	delay_us(1000);
+	delay_ms(1);
 	bcmgenet_disable_dma(unit);
 	/* Disable MAC transmit. TX DMA disabled must be done before this */
 	mmio_clear32(BCMGENET_REG(unit, UMAC_CMD), CMD_TX_EN);
-	delay_us(1000);
+	delay_ms(1);
 
 	bcmgenet_intr_disable(unit);
 	RemIntServerEx(unit->irq0_number, &unit->irq0_isr);

--- a/genet.device/src/device.c
+++ b/genet.device/src/device.c
@@ -154,6 +154,17 @@ static s32 genet_open_libraries(struct GenetDevice *base)
     return 0;
 }
 
+/* reset_guard prepare: stop RX/TX DMA before the machine resets, so the
+ * GENET stops writing into RAM the next OS session will reuse. */
+static void genet_reset_prepare(APTR user)
+{
+    struct GenetDevice *base = user;
+    struct GenetUnit *unit = base->unit;
+
+    if (unit && unit->state == STATE_ONLINE)
+        bcmgenet_reset_quiesce(unit);
+}
+
 APTR initFunction(struct GenetDevice *base asm("d0"), ULONG segList asm("a0"), struct ExecBase *_SysBase asm("a6"))
 {
     (void)_SysBase;
@@ -163,6 +174,10 @@ APTR initFunction(struct GenetDevice *base asm("d0"), ULONG segList asm("a0"), s
     base->unit = NULL;
     base->utilityBase = NULL;
     base->gic400Base = NULL;
+
+    if (!reset_guard_install(&base->resetGuard, genet_reset_prepare, base,
+                             (CONST_STRPTR)"genet.device"))
+        Kprintf("[genet] %s: reset guard install failed\n", __func__);
 
     return base;
 }
@@ -387,6 +402,14 @@ ULONG expungeLib(struct GenetDevice *base asm("a6"))
     }
     else
     {
+        /* The ColdReboot vector may have been re-patched on top of our
+         * stub — then the code must stay resident. */
+        if (!reset_guard_remove(&base->resetGuard))
+        {
+            KprintfH("[genet] %s: reset guard not removable, staying resident\n", __func__);
+            return NULL;
+        }
+
         ULONG segList = base->segList;
 
         /* Remove yourself from list of devices */

--- a/genet.device/src/phy.c
+++ b/genet.device/src/phy.c
@@ -628,7 +628,7 @@ static s32 get_phy_id(struct phy_device *phydev)
 struct phy_device *phy_create(struct GenetUnit *dev, phy_interface_t interface)
 {
 	KprintfH("[genet] %s: base=0x%lx phyaddr=%ld\n", __func__, dev->genetBase, dev->phyaddr);
-	struct phy_device *phydev = AllocPooled(dev->memoryPool, sizeof(*phydev));
+	struct phy_device *phydev = pool_alloc(dev->metaPool, sizeof(*phydev));
 	if (!phydev)
 	{
 		Kprintf("[genet] %s: Failed to allocate MDIO bus\n", __func__);
@@ -660,7 +660,7 @@ struct phy_device *phy_create(struct GenetUnit *dev, phy_interface_t interface)
 		}
 	}
 
-	FreePooled(dev->memoryPool, phydev, sizeof(*phydev));
+	pool_free(dev->metaPool, phydev);
 	Kprintf("[genet] %s: Could not get PHY\n", __func__);
 	return NULL;
 }
@@ -668,5 +668,5 @@ struct phy_device *phy_create(struct GenetUnit *dev, phy_interface_t interface)
 void phy_destroy(struct phy_device *phydev)
 {
 	KprintfH("[genet] %s: phy=%ld\n", __func__, phydev->addr);
-	FreePooled(phydev->unit->memoryPool, phydev, sizeof(*phydev));
+	pool_free(phydev->unit->metaPool, phydev);
 }

--- a/genet.device/src/phy.c
+++ b/genet.device/src/phy.c
@@ -353,7 +353,7 @@ static s32 genphy_update_link(struct phy_device *phydev)
 			}
 
 			mii_reg = mdio_read(phydev, MII_BMSR);
-			delay_us(50 * 1000); /* 50 ms */
+			delay_ms(50);
 		}
 		Kprintf(" done\n");
 		phydev->link = TRUE;
@@ -581,7 +581,7 @@ s32 phy_reset(struct phy_device *phydev)
 			Kprintf("[genet] %s: PHY status read failed\n", __func__);
 			return reg;
 		}
-		delay_us(1000);
+		delay_ms(1);
 	}
 
 	if (reg & BMCR_RESET)

--- a/genet.device/src/unit.c
+++ b/genet.device/src/unit.c
@@ -64,35 +64,40 @@ u32 UnitOpen(struct GenetUnit *unit, u32 unitNumber, u32 flags, struct Opener *o
 	unit->use_miami_workaround = unit->device->runtimeConfig.use_miami_workaround;
 	unit->budget = unit->device->runtimeConfig.budget;
 
-	unit->memoryPool = CreatePool(MEMF_FAST | MEMF_PUBLIC, 16384, 8192);
-	if (unit->memoryPool == NULL)
+	/* DMA buffers (rings, rx buffer, tx staging) must live in Emu68 (Pi-DRAM) RAM the
+	 * GENET DMA engine can reach, so the DMA pool is region-restricted; with no device
+	 * tree there is no reachable region and we refuse to open.  CPU-only metadata uses a
+	 * separate ordinary Exec pool. */
+	dma_mem_init(&unit->dma_ctx);
+	unit->dmaPool = dma_pool_create(&unit->dma_ctx);
+	unit->metaPool = CreatePool(MEMF_FAST | MEMF_PUBLIC, 16384, 8192);
+
+	u32 result;
+	if (unit->dmaPool == NULL || unit->metaPool == NULL)
 	{
-		Kprintf("[genet] %s: Failed to create memory pool\n", __func__);
-		return S2ERR_NO_RESOURCES;
+		Kprintf("[genet] %s: Failed to create memory pools\n", __func__);
+		result = S2ERR_NO_RESOURCES;
+		goto fail;
 	}
 	_NewMinList(&unit->multicastRanges);
 	unit->multicastCount = 0;
 
 	_NewMinList(&unit->openers);
 
-	u32 result = DevTreeParse(unit);
+	result = DevTreeParse(unit);
 	if (result != S2ERR_NO_ERROR)
 	{
 		Kprintf("[genet] %s: Failed to parse device tree: %ld\n", __func__, result);
-		DeletePool(unit->memoryPool);
-		unit->memoryPool = NULL;
-		return result;
+		goto fail;
 	}
-	
+
 	/* On first open, we initialize current MAC to 0 to indicate it was not set yet */
 	mem_zero(unit->currentMacAddress, sizeof(unit->currentMacAddress));
 	result = UnitTaskStart(unit);
 	if (result != S2ERR_NO_ERROR)
 	{
 		Kprintf("[genet] %s: Failed to start unit task: %ld\n", __func__, result);
-		DeletePool(unit->memoryPool);
-		unit->memoryPool = NULL;
-		return result;
+		goto fail;
 	}
 
 	if (opener != NULL)
@@ -101,6 +106,19 @@ u32 UnitOpen(struct GenetUnit *unit, u32 unitNumber, u32 flags, struct Opener *o
 	}
 
 	return S2ERR_NO_ERROR;
+
+fail:
+	if (unit->dmaPool)
+	{
+		dma_pool_delete(unit->dmaPool);
+		unit->dmaPool = NULL;
+	}
+	if (unit->metaPool)
+	{
+		DeletePool(unit->metaPool);
+		unit->metaPool = NULL;
+	}
+	return result;
 }
 
 u32 UnitConfigure(struct GenetUnit *unit)
@@ -155,8 +173,10 @@ u32 UnitClose(struct GenetUnit *unit, struct Opener *opener)
 			UnitOffline(unit);
 		}
 		UnitTaskStop(unit);
-		DeletePool(unit->memoryPool);
-		unit->memoryPool = NULL;
+		dma_pool_delete(unit->dmaPool);
+		unit->dmaPool = NULL;
+		DeletePool(unit->metaPool);
+		unit->metaPool = NULL;
 		unit->state = STATE_UNCONFIGURED;
 	}
 	else if (opener != NULL)

--- a/genet.device/src/unit_commands_mcast.c
+++ b/genet.device/src/unit_commands_mcast.c
@@ -72,7 +72,7 @@ u32 Do_S2_ADDMULTICASTADDRESSES(struct IOSana2Req *io)
     }
 
     /* No range was found. Create new one and add the multicast range on the WiFi module */
-    struct MulticastRange *range = AllocPooled(unit->memoryPool, sizeof(struct MulticastRange));
+    struct MulticastRange *range = pool_alloc(unit->metaPool, sizeof(struct MulticastRange));
     if (!range)
     {
         Kprintf("[genet] %s: Failed to allocate memory for multicast range\n", __func__);
@@ -131,7 +131,7 @@ u32 Do_S2_DELMULTICASTADDRESSES(struct IOSana2Req *io)
             if (range->useCount == 0)
             {
                 RemoveMinNode((struct MinNode *)range);
-                FreePooled(unit->memoryPool, range, sizeof(struct MulticastRange));
+                pool_free(unit->metaPool, range);
 
                 u32 count = (u32)(upper_bound - lower_bound + 1);
                 unit->multicastCount -= count;

--- a/genet.device/src/unit_task.c
+++ b/genet.device/src/unit_task.c
@@ -59,7 +59,7 @@ void UnitSubmitControlAsync(struct GenetUnit *unit, UWORD command, union UnitCon
     if (unit == NULL || unit->controlPort == NULL)
         return;
 
-    struct UnitControlMsg *msg = pool_alloc(&unit->memoryPool, sizeof(struct UnitControlMsg));
+    struct UnitControlMsg *msg = pool_alloc(unit->metaPool, sizeof(struct UnitControlMsg));
     if (msg == NULL)
     {
         Kprintf("[genet] %s: Failed to allocate message for async unit control\n", __func__);
@@ -187,7 +187,7 @@ static void UnitTask(struct GenetUnit *unit, struct Task *parent)
                 if(cmsg->msg.mn_ReplyPort != NULL)
                     ReplyMsg(&cmsg->msg);
                 else
-                    pool_free(&unit->memoryPool, cmsg);
+                    pool_free(unit->metaPool, cmsg);
             }
             if (budget == 0)
             {


### PR DESCRIPTION
This pull request implements a major update to the GENET network driver, focusing on robust reset handling, improved memory management for DMA and metadata, and various reliability and maintainability improvements. The most significant changes are the addition of a "reset guard" to safely quiesce DMA before system resets, a rework of memory pool allocation to properly separate DMA-reachable and CPU-only memory, and the introduction of explicit checks for DMA buffer reachability. Several code cleanups and minor bug fixes are also included.

**Reset handling improvements:**
- Added a "reset guard" mechanism (`reset_guard`) to ensure GENET DMA is properly quiesced before Amiga resets (both soft and hard reboots), preventing the controller from writing into RAM that the next OS session will reuse. This includes a new `bcmgenet_reset_quiesce()` function and integration with device initialization and expunge logic. [[1]](diffhunk://#diff-a7e82d546f582cbcc39926a5695eebabcc69bfbf4a315da153d62e32403bde0eR157-R167) [[2]](diffhunk://#diff-a7e82d546f582cbcc39926a5695eebabcc69bfbf4a315da153d62e32403bde0eR178-R181) [[3]](diffhunk://#diff-a7e82d546f582cbcc39926a5695eebabcc69bfbf4a315da153d62e32403bde0eR405-R412) [[4]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L727-R751) AGENTS.md [[5]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L27-R27) README.md [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R20) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58) [[8]](diffhunk://#diff-b5fe0a7ca9d44d3977660329d37e6a0bf9a3271934856555137620b75fb2fec3R269)

**DMA and metadata memory management:**
- Reworked unit memory allocation: DMA buffers are now allocated from a region-restricted pool in Emu68 (Pi-DRAM) RAM (`dmaPool`), while CPU-only metadata uses a separate Exec pool (`metaPool`). DMA reachability is determined by an explicit predicate (`dma_addr_reachable`) instead of a hardcoded address check. [[1]](diffhunk://#diff-b5fe0a7ca9d44d3977660329d37e6a0bf9a3271934856555137620b75fb2fec3L181-R185) [[2]](diffhunk://#diff-e3381d53a290af412d2bfe2a8a6ee247186196fae596c46aa956a637992d99afL147-R155) [[3]](diffhunk://#diff-e3381d53a290af412d2bfe2a8a6ee247186196fae596c46aa956a637992d99afL210-R211) [[4]](diffhunk://#diff-21bbe5bee860ac0ac239f9179af2236fd45d83c97d015224c7f5799c2c54e638L67-R91) [[5]](diffhunk://#diff-21bbe5bee860ac0ac239f9179af2236fd45d83c97d015224c7f5799c2c54e638L93-R100) [[6]](diffhunk://#diff-21bbe5bee860ac0ac239f9179af2236fd45d83c97d015224c7f5799c2c54e638R109-R121) [[7]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L283-R283) [[8]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L348-R348) [[9]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L360-R360) [[10]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L561-R571) [[11]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L644-R647) [[12]](diffhunk://#diff-0aab20d5be49cdbabe011744f2b11f5ed2a4f5ed9eab79a3781ac0d34ac8da0aL631-R631) [[13]](diffhunk://#diff-0aab20d5be49cdbabe011744f2b11f5ed2a4f5ed9eab79a3781ac0d34ac8da0aL663-R671)

**Cache coherency and DMA correctness:**
- Added a `CachePreDMA()` call for the RX buffer to ensure cache coherency before the controller writes into it. [[1]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L561-R571) README.md [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R20)

**General codebase improvements and bug fixes:**
- Replaced several `delay_us()` calls with `delay_ms()` for improved timing accuracy and code clarity. [[1]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L114-R114) [[2]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L727-R751) [[3]](diffhunk://#diff-0aab20d5be49cdbabe011744f2b11f5ed2a4f5ed9eab79a3781ac0d34ac8da0aL356-R356) [[4]](diffhunk://#diff-0aab20d5be49cdbabe011744f2b11f5ed2a4f5ed9eab79a3781ac0d34ac8da0aL584-R584)
- Updated allocation and free routines for metadata to use the new `metaPool` and associated helpers. [[1]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L283-R283) [[2]](diffhunk://#diff-baab70150723700617705177cca0692d2f16ac18db6f2911541b687b7c470ec2L348-R348) [[3]](diffhunk://#diff-0aab20d5be49cdbabe011744f2b11f5ed2a4f5ed9eab79a3781ac0d34ac8da0aL631-R631) [[4]](diffhunk://#diff-0aab20d5be49cdbabe011744f2b11f5ed2a4f5ed9eab79a3781ac0d34ac8da0aL663-R671)
- Minor code cleanups, version bump to 3.10, and improved ROM-ability check in CMake. (CMakeLists.txt [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R2) [[2]](diffhunk://#diff-a06a41a6a06d6d4a97c2bf663c968b9d8badabb1829e0a872fc1c77a25560231R80-R82) README.md [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R20)

**Documentation updates:**
- Updated documentation to reflect the new reset guard feature, improved memory management, and the current known bug status. (README.md [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58) AGENTS.md [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L27-R27)

These changes collectively make the driver more robust, especially across system resets, and improve maintainability and correctness of DMA operations.